### PR TITLE
GCP Client Options

### DIFF
--- a/examples/gcp/gcp_example.go
+++ b/examples/gcp/gcp_example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/jack-mcveigh/secretly"
@@ -39,7 +40,7 @@ type SecretConfig struct {
 }
 
 func main() {
-	client, err := secretlygcp.NewClient(gcpProjectId)
+	client, err := secretlygcp.NewClient(context.Background(), gcpProjectId)
 	if err != nil {
 		log.Fatalf("Failed to initialize gcp secret manager client: %v", err)
 	}

--- a/gcp/client.go
+++ b/gcp/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"github.com/jack-mcveigh/secretly"
 	"github.com/jack-mcveigh/secretly/internal"
+	"google.golang.org/api/option"
 )
 
 const secretVersionsFormat = "projects/%s/secrets/%s/versions/%s"
@@ -33,7 +34,7 @@ var _ secretly.Client = (*client)(nil)
 
 // NewClient constructs a GCP client with the projectID
 // TODO: support options for secretmanager.NewClient
-func NewClient(projectID string) (*client, error) {
+func NewClient(ctx context.Context, projectID string, opts ...option.ClientOption) (*client, error) {
 	smc, err := secretmanager.NewClient(context.TODO())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adds configuring the GCP client via "google.golang.org/api/option" ClientOptions, like the secret manager package, "cloud.google.com/go/secretmanager/apiv1".

