### PR TITLE
Handle acronyms in secret names and keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,9 @@ Secretly provides two options for specifying secret versions other than the __ve
 
         ...
         ```
+
+## References
+
+* [envconfig](https://github.com/kelseyhightower/envconfig)
+
+    The API for secretly was inspired by and borrows from envconfig. A simple yet powerful package for managing configuration data from environment variables.

--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,6 @@ import (
 
 var (
 	ErrInvalidSpecification        = errors.New("specification must be a struct pointer")
-	ErrInvalidStructTagValue       = errors.New("invalid struct tag key value")
 	ErrInvalidSecretType           = errors.New("invalid secret type")
 	ErrInvalidSecretVersion        = errors.New("invalid secret version")
 	ErrSecretTypeDoesNotSupportKey = errors.New("secret type does not support \"key\"")

--- a/examples/gcp/example.go
+++ b/examples/gcp/example.go
@@ -41,7 +41,7 @@ type SecretConfig struct {
 
 func main() {
 	client, err := secretlygcp.NewClient(context.Background(), secretlygcp.Config{
-		ProjectId: gcpProjectId,
+		ProjectID: gcpProjectId,
 	})
 	if err != nil {
 		log.Fatalf("Failed to initialize gcp secret manager client: %v", err)

--- a/field.go
+++ b/field.go
@@ -13,13 +13,13 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-// Default values for optional field tags
+// Default values for optional field tags.
 const (
-	// defaults
+	// Defaults.
 	DefaultType    = "text"
 	DefaultVersion = "0"
 
-	// tags
+	// Tags.
 	tagIgnored    = "ignored"
 	tagKey        = "key"
 	tagName       = "name"
@@ -31,6 +31,10 @@ const (
 var (
 	regexGatherWords = regexp.MustCompile("([^A-Z]+|[A-Z]+[^A-Z]+|[A-Z]+)")
 	regexAcronym     = regexp.MustCompile("([A-Z]+)([A-Z][^A-Z]+)")
+
+	ErrInvalidJSONSecret = errors.New("secret is not valid json")
+	ErrInvalidYAMLSecret = errors.New("secret is not valid yaml")
+	ErrSecretMissingKey  = errors.New("secret is missing provided key")
 )
 
 // Field represents a field in a struct,
@@ -66,6 +70,7 @@ func NewField(fValue reflect.Value, fStructField reflect.StructField) (Field, er
 			Err:  err,
 		}
 	}
+
 	if !ok {
 		newField.SplitWords = false
 	}
@@ -80,9 +85,11 @@ func NewField(fValue reflect.Value, fStructField reflect.StructField) (Field, er
 			Err:  err,
 		}
 	}
+
 	if !ok {
 		newField.SecretType = DefaultType
 	}
+
 	switch newField.SecretType {
 	case "text", "json", "yaml":
 	default:
@@ -103,6 +110,7 @@ func NewField(fValue reflect.Value, fStructField reflect.StructField) (Field, er
 			Err:  err,
 		}
 	}
+
 	if !ok {
 		newField.SecretName = fStructField.Name
 		if newField.SplitWords {
@@ -168,8 +176,10 @@ func (f *Field) Name() string {
 		if f.SplitWords {
 			delimiter = "_"
 		}
+
 		name += delimiter + f.MapKeyName
 	}
+
 	return name
 }
 
@@ -194,7 +204,8 @@ func (f *Field) setText(b []byte) error {
 
 	byteString := string(b)
 
-	typ := f.Value.Type()
+	valueType := f.Value.Type()
+
 	switch f.Value.Kind() {
 	case reflect.String:
 		f.Value.SetString(byteString)
@@ -205,26 +216,29 @@ func (f *Field) setText(b []byte) error {
 			err   error
 		)
 
-		if f.Value.Kind() == reflect.Int64 && typ.PkgPath() == "time" && typ.Name() == "Duration" {
+		if f.Value.Kind() == reflect.Int64 && valueType.PkgPath() == "time" && valueType.Name() == "Duration" {
 			var d time.Duration
 			d, err = time.ParseDuration(byteString)
 			value = int64(d)
 		} else {
-			value, err = strconv.ParseInt(byteString, 0, typ.Bits())
+			value, err = strconv.ParseInt(byteString, 0, valueType.Bits())
 		}
 		if err != nil {
-			t := fmt.Sprintf("int%d", typ.Bits())
+			t := fmt.Sprintf("int%d", valueType.Bits())
+
 			return fmt.Errorf(ErrFailedConvertFormat, f.SecretName, f.MapKeyName, t, err)
 		}
 
 		f.Value.SetInt(value)
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		value, err := strconv.ParseUint(byteString, 0, typ.Bits())
+		value, err := strconv.ParseUint(byteString, 0, valueType.Bits())
 		if err != nil {
-			t := fmt.Sprintf("uint%d", typ.Bits())
+			t := fmt.Sprintf("uint%d", valueType.Bits())
+
 			return fmt.Errorf(ErrFailedConvertFormat, f.SecretName, f.MapKeyName, t, err)
 		}
+
 		f.Value.SetUint(value)
 
 	case reflect.Bool:
@@ -232,14 +246,17 @@ func (f *Field) setText(b []byte) error {
 		if err != nil {
 			return fmt.Errorf(ErrFailedConvertFormat, f.SecretName, f.MapKeyName, "bool", err)
 		}
+
 		f.Value.SetBool(value)
 
 	case reflect.Float32, reflect.Float64:
-		value, err := strconv.ParseFloat(byteString, typ.Bits())
+		value, err := strconv.ParseFloat(byteString, valueType.Bits())
 		if err != nil {
-			t := fmt.Sprintf("float%d", typ.Bits())
+			t := fmt.Sprintf("float%d", valueType.Bits())
+
 			return fmt.Errorf(ErrFailedConvertFormat, f.SecretName, f.MapKeyName, t, err)
 		}
+
 		f.Value.SetFloat(value)
 	}
 
@@ -253,14 +270,14 @@ func (f *Field) setJSON(b []byte) error {
 
 	err := json.Unmarshal(b, &secretMap)
 	if err != nil {
-		return errors.New("secret is not valid json")
+		return ErrInvalidJSONSecret
 	}
 
 	if value, ok := secretMap[f.MapKeyName]; ok {
 		return f.setText([]byte(value))
 	}
 
-	return fmt.Errorf("the json secret, \"%s\" does not contain key \"%s\"", f.SecretName, f.MapKeyName)
+	return fmt.Errorf("%w: secret \"%s\" missing \"%s\"", ErrSecretMissingKey, f.SecretName, f.MapKeyName)
 }
 
 // setYAML sets the field's underlying value,
@@ -270,14 +287,14 @@ func (f *Field) setYAML(b []byte) error {
 
 	err := yaml.Unmarshal(b, &secretMap)
 	if err != nil {
-		return errors.New("secret is not valid yaml")
+		return ErrInvalidYAMLSecret
 	}
 
 	if value, ok := secretMap[f.MapKeyName]; ok {
 		return f.setText([]byte(value))
 	}
 
-	return fmt.Errorf("the yaml secret, \"%s\" does not contain key \"%s\"", f.SecretName, f.MapKeyName)
+	return fmt.Errorf("%w: secret \"%s\" missing \"%s\"", ErrSecretMissingKey, f.SecretName, f.MapKeyName)
 }
 
 // parseOptionalStructTagKey parses the provided key's value from the struct field,
@@ -295,24 +312,29 @@ func parseOptionalStructTagKey[T any](structField reflect.StructField, key strin
 			if err != nil {
 				break
 			}
+
 			value = any(i).(T)
 		case bool:
 			b, err := strconv.ParseBool(raw)
 			if err != nil {
 				break
 			}
+
 			value = any(b).(T)
 		}
 
 		if err != nil {
-			return value, false, fmt.Errorf("%w: %w", ErrInvalidStructTagValue, err)
+			return value, false, fmt.Errorf("invalid struct tag key value: %w", err)
 		}
 	}
+
 	return value, ok, nil
 }
 
 // splitWords converts the camelCase/PascalCase string, s, to snake_case
 func splitWords(s string) string {
+	const minAcronymLength = 3
+
 	words := regexGatherWords.FindAllStringSubmatch(s, -1)
 	if len(words) == 0 {
 		return s
@@ -320,7 +342,7 @@ func splitWords(s string) string {
 
 	var name []string
 	for _, words := range words {
-		if m := regexAcronym.FindStringSubmatch(words[0]); len(m) == 3 {
+		if m := regexAcronym.FindStringSubmatch(words[0]); len(m) == minAcronymLength {
 			name = append(name, m[1], m[2])
 		} else {
 			name = append(name, words[0])

--- a/gcp/client.go
+++ b/gcp/client.go
@@ -22,8 +22,8 @@ type gcpsmc interface {
 
 // Config provides both GCP Secret Manager client and secretly wrapper configurations.
 type Config struct {
-	// ProjectId identifies the GCP project from which to retrieve the secrets.
-	ProjectId string
+	// ProjectID identifies the GCP project from which to retrieve the secrets.
+	ProjectID string
 
 	SecretlyConfig secretly.Config
 }
@@ -63,7 +63,7 @@ func NewClient(ctx context.Context, cfg Config, opts ...option.ClientOption) (*C
 
 	c := &Client{
 		client:      smc,
-		projectId:   cfg.ProjectId,
+		projectId:   cfg.ProjectID,
 		secretCache: sc,
 	}
 	return c, nil
@@ -80,7 +80,7 @@ func Wrap(client *secretmanager.Client, cfg Config) *Client {
 
 	c := &Client{
 		client:      client,
-		projectId:   cfg.ProjectId,
+		projectId:   cfg.ProjectID,
 		secretCache: sc,
 	}
 	return c

--- a/process.go
+++ b/process.go
@@ -3,10 +3,7 @@ package secretly
 import (
 	"context"
 	"reflect"
-	"regexp"
 )
-
-var regexMatchCapitals = regexp.MustCompile("([a-z0-9])([A-Z])")
 
 // Process interprets the provided specification,
 // resolving the described secrets

--- a/secret_cache.go
+++ b/secret_cache.go
@@ -18,8 +18,8 @@ type noOpSecretCache struct{}
 // meant to be used for disabling secret caching.
 func NewNoOpSecretCache() noOpSecretCache { return noOpSecretCache{} }
 
-func (noOpSecretCache) Add(name, version string, content []byte) {}
-func (noOpSecretCache) Get(name, version string) ([]byte, bool)  { return nil, false }
+func (noOpSecretCache) Add(_, _ string, content []byte) {}
+func (noOpSecretCache) Get(_, _ string) ([]byte, bool)  { return nil, false }
 
 // secretCacheEntry is a map of versions to the secret content.
 type secretCacheEntry map[string][]byte


### PR DESCRIPTION
* Handle acronyms in secret names and keys when using "split_words: true"
* Satisfy some linter suggestions.
* Wrap errors in exported functions.